### PR TITLE
Update UploadCard.tsx

### DIFF
--- a/src/components/UploadCard/UploadCard.tsx
+++ b/src/components/UploadCard/UploadCard.tsx
@@ -1,25 +1,46 @@
-import { Button, Center, Divider, Group, rem, Stack, Text, Title } from '@mantine/core'
-import { Paper } from '@components'
-import { Dropzone } from '@mantine/dropzone'
-import { IconFile3d, IconUpload, IconX } from '@tabler/icons-react'
-import { useNavigate } from 'react-router-dom'
-import { useState } from 'react'
-import { useValidationContext } from '@context'
-import { processFile } from './processFile.ts'
+import { Button, Center, Divider, Group, rem, Stack, Text, Title } from '@mantine/core';
+import { Paper } from '@components';
+import { Dropzone, FileRejection } from '@mantine/dropzone';
+import { IconFile3d, IconUpload, IconX } from '@tabler/icons-react';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useValidationContext } from '@context';
+import { processFile } from './processFile.ts';
 
 export const UploadCard = () => {
-  const navigate = useNavigate()
-  const { dispatch } = useValidationContext()
-  const [files, setFiles] = useState<File[]>([])
+  const navigate = useNavigate();
+  const { dispatch } = useValidationContext();
+  const [files, setFiles] = useState<File[]>([]);
 
   const handleClick = () => {
-    if (!files) return
+    if (!files.length) return;
     files.forEach((file) => {
-      processFile({ file: file as File, dispatch, fileId: file.name })
-    })
-    setFiles([])
-    navigate('/results')
-  }
+      processFile({ file: file as File, dispatch, fileId: file.name });
+    });
+    setFiles([]);
+    navigate('/results');
+  };
+
+  const handleDrop = (acceptedFiles: File[]) => {
+    console.log('Accepted files:', acceptedFiles);
+    setFiles((prevFiles) => [...prevFiles, ...acceptedFiles]);
+  };
+
+  const handleReject = (fileRejections: FileRejection[]) => {
+    console.log('Rejected files:', fileRejections);
+  };
+
+  // Custom validator to check for .ifc file extension
+  const fileValidator = (file: File) => {
+    const validExtension = file.name.endsWith('.ifc');
+    if (!validExtension) {
+      return {
+        code: 'file-invalid-type',
+        message: 'Invalid file type. Only .ifc files are allowed.',
+      };
+    }
+    return null;
+  };
 
   return (
     <Stack>
@@ -29,11 +50,11 @@ export const UploadCard = () => {
         </Center>
         <Divider py={8} />
         <Dropzone
-          onDrop={(files) => setFiles((prevFiles) => [...prevFiles, ...files])}
-          onReject={(files) => console.log('rejected files', files)}
+          onDrop={handleDrop}
+          onReject={handleReject}
           maxSize={500 * 1024 ** 2}
-          accept={['application/p21']}
           multiple={true}
+          validator={fileValidator} // Use the correct prop name 'validator'
         >
           <Group justify='center' gap='xl' mih={220} style={{ pointerEvents: 'none' }}>
             <Dropzone.Accept>
@@ -70,10 +91,10 @@ export const UploadCard = () => {
             ))}
           </div>
         </Dropzone>
-        <Button color='#319555' mt='md' radius='md' onClick={handleClick} disabled={!files}>
+        <Button color='#319555' mt='md' radius='md' onClick={handleClick} disabled={!files.length}>
           Validate
         </Button>
       </Paper>
     </Stack>
-  )
-}
+  );
+};

--- a/src/components/UploadCard/UploadCard.tsx
+++ b/src/components/UploadCard/UploadCard.tsx
@@ -1,46 +1,46 @@
-import { Button, Center, Divider, Group, rem, Stack, Text, Title } from '@mantine/core';
-import { Paper } from '@components';
-import { Dropzone, FileRejection } from '@mantine/dropzone';
-import { IconFile3d, IconUpload, IconX } from '@tabler/icons-react';
-import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
-import { useValidationContext } from '@context';
-import { processFile } from './processFile.ts';
+import { Button, Center, Divider, Group, rem, Stack, Text, Title } from '@mantine/core'
+import { Paper } from '@components'
+import { Dropzone, FileRejection } from '@mantine/dropzone'
+import { IconFile3d, IconUpload, IconX } from '@tabler/icons-react'
+import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { useValidationContext } from '@context'
+import { processFile } from './processFile.ts'
 
 export const UploadCard = () => {
-  const navigate = useNavigate();
-  const { dispatch } = useValidationContext();
-  const [files, setFiles] = useState<File[]>([]);
+  const navigate = useNavigate()
+  const { dispatch } = useValidationContext()
+  const [files, setFiles] = useState<File[]>([])
 
   const handleClick = () => {
-    if (!files.length) return;
+    if (!files.length) return
     files.forEach((file) => {
-      processFile({ file: file as File, dispatch, fileId: file.name });
-    });
-    setFiles([]);
-    navigate('/results');
-  };
+      processFile({ file: file as File, dispatch, fileId: file.name })
+    })
+    setFiles([])
+    navigate('/results')
+  }
 
   const handleDrop = (acceptedFiles: File[]) => {
-    console.log('Accepted files:', acceptedFiles);
-    setFiles((prevFiles) => [...prevFiles, ...acceptedFiles]);
-  };
+    console.log('Accepted files:', acceptedFiles)
+    setFiles((prevFiles) => [...prevFiles, ...acceptedFiles])
+  }
 
   const handleReject = (fileRejections: FileRejection[]) => {
-    console.log('Rejected files:', fileRejections);
-  };
+    console.log('Rejected files:', fileRejections)
+  }
 
   // Custom validator to check for .ifc file extension
   const fileValidator = (file: File) => {
-    const validExtension = file.name.endsWith('.ifc');
+    const validExtension = file.name.endsWith('.ifc')
     if (!validExtension) {
       return {
         code: 'file-invalid-type',
         message: 'Invalid file type. Only .ifc files are allowed.',
-      };
+      }
     }
-    return null;
-  };
+    return null
+  }
 
   return (
     <Stack>
@@ -96,5 +96,5 @@ export const UploadCard = () => {
         </Button>
       </Paper>
     </Stack>
-  );
-};
+  )
+}


### PR DESCRIPTION
To ensure .ifc files are correctly accepted, we can use a custom validator instead of relying on MIME types. This custom validator will explicitly check for .ifc extensions.