### PR TITLE
Refactor micropip installation in pyodideWorker.js 

### DIFF
--- a/public/pyodideWorker.js
+++ b/public/pyodideWorker.js
@@ -225,10 +225,10 @@ await micropip.install('https://cdn.jsdelivr.net/gh/IfcOpenShell/wasm-wheels@33b
     })
 
     await pyodide.runPythonAsync(`
-await micropip.install('lark')
-await micropip.install('ifctester')
-await micropip.install('bcf-client')
-await micropip.install('pystache')
+import micropip
+print("Attempting to install ifctester 0.8.1, bcf-client 0.8.1 and dependencies...")
+await micropip.install(['lark', 'ifctester==0.8.1', 'bcf-client==0.8.1', 'pystache'], keep_going=True)
+print("Finished attempting to install ifctester 0.8.1, bcf-client 0.8.1 and dependencies.")
     `)
 
     self.postMessage({


### PR DESCRIPTION
Refactor micropip installation process in pyodideWorker.js to install IfcOpenShell modules with version specifications. This resolves mismatch in versioning that lead to wasm error (was missing 'odfpy' because that gets now used in 0.8.2 but has no public wheel)